### PR TITLE
Add Story Endpoint to Endpoints module declaration

### DIFF
--- a/lib/tracker_api.rb
+++ b/lib/tracker_api.rb
@@ -27,6 +27,7 @@ module TrackerApi
     autoload :Project, 'tracker_api/endpoints/project'
     autoload :Projects, 'tracker_api/endpoints/projects'
     autoload :Stories, 'tracker_api/endpoints/stories'
+    autoload :Story, 'tracker_api/endpoints/story'
   end
 
   module Resources


### PR DESCRIPTION
While attempting to call `.story([id])` on a project object, received error:

> NameError: uninitialized constant Tracker::Endpoints::Story

Found we weren't actually including that endpoint. =)
