### PR TITLE
Faraday upgrade

### DIFF
--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -19,7 +19,7 @@ VCR.configure do |c|
   c.ignore_localhost         = true
   c.cassette_library_dir     = File.expand_path('../vcr/cassettes', __FILE__).to_s
   c.default_cassette_options = { serialize_with: :json }
-  c.hook_into :faraday
+  c.hook_into :excon
   c.allow_http_connections_when_no_cassette = false
 end
 

--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'excon'
   spec.add_development_dependency 'multi_json'
   # spec.add_development_dependency 'byebug'
   # spec.add_development_dependency 'pry-byebug'
@@ -30,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable'
   spec.add_dependency 'virtus'
-  spec.add_dependency 'faraday', '~> 0.8.0'
+  spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'faraday_middleware'
   # spec.add_dependency 'excon'
 end


### PR DESCRIPTION
Updated Faraday to 0.9.0 so I could use tracker_api in conjunction with
http://peter-murach.github.io/github/.

I had to add excon as a dependency and make VCR hook into it because of a bug in Faraday.  The discussion of the issue is here: vcr/vcr#386
