### PR TITLE
Make it possible to pass auto_paginate: false per request.

### DIFF
--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -67,11 +67,12 @@ module TrackerApi
     # @return [Array]
     def paginate(path, options = {}, &block)
       opts           = parse_query_and_convenience_headers path, options.dup
+      auto_paginate  = opts[:params].delete(:auto_paginate) { |k| @auto_paginate }
       @last_response = request :get, opts
       data           = @last_response.body
       raise TrackerApi::Errors::UnexpectedData, 'Array expected' unless data.is_a? Array
 
-      if @auto_paginate
+      if auto_paginate
         pager = Pagination.new @last_response.headers
 
         while pager.more?

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -101,6 +101,17 @@ describe TrackerApi::Client do
       end
     end
 
+    it 'allows auto pagination to be turned off when just a subset of a list is desired' do
+      VCR.use_cassette('client: get limited stories with no pagination', record: :new_episodes) do
+        project = client.project(project_id)
+
+        # force no pagination
+        stories = project.stories(limit: 7, auto_paginate: false)
+        stories.wont_be_empty
+        stories.length.must_equal 7
+      end
+    end
+
     it 'can handle negative offsets' do
       VCR.use_cassette('client: done iterations with pagination', record: :new_episodes) do
         project = client.project(project_id)


### PR DESCRIPTION
- For time when you want a small subset of the results.
