### PR TITLE
Fix DEPRECATION WARNING for Rails5

### DIFF
--- a/lib/tracker_api/resources/base.rb
+++ b/lib/tracker_api/resources/base.rb
@@ -20,7 +20,7 @@ module TrackerApi
           super
 
           # always reset dirty tracking on initialize
-          reset_changes
+          clear_changes_information
         end
 
         private


### PR DESCRIPTION
Hi, there. I found deprecation warning. 
please, fix it.

> DEPRECATION WARNING: `#reset_changes` is deprecated and will be removed on
  Rails 5. Please use `#clear_changes_information` instead.