### PR TITLE
Fix `undefined method blank?'

### DIFF
--- a/lib/tracker_api.rb
+++ b/lib/tracker_api.rb
@@ -4,6 +4,8 @@ require 'tracker_api/version'
 require 'virtus'
 require 'faraday'
 require 'faraday_middleware'
+require 'active_support'
+require 'active_support/core_ext'
 
 # stdlib
 require 'addressable/uri'


### PR DESCRIPTION
- require active_support/core_ext for blank? method
- https://github.com/dashofcode/tracker_api/blob/v0.2.8/lib/tracker_api/client.rb#L189

Other fix method.

```diff
- if (method == :post || method == :put) && options[:body].blank?
+ if (method == :post || method == :put) && (options[:body].nil? || options[:body].empty?)
```