### PR TITLE
Issue #43 fix: Updated gemspec with minimum version of activemodel

### DIFF
--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'excon'
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'activemodel'
+  spec.add_dependency 'activemodel', '>= 4.0.0'
 end


### PR DESCRIPTION
This is needed because older versions of activemodel cause an exception to occur. 