### PR TITLE
Conditionally load core_ext/blank depending on AS

### DIFF
--- a/lib/tracker_api.rb
+++ b/lib/tracker_api.rb
@@ -4,7 +4,11 @@ require 'tracker_api/version'
 require 'virtus'
 require 'faraday'
 require 'faraday_middleware'
-require 'core_ext/object/blank'
+if defined?(ActiveSupport)
+  require 'active_support/core_ext/object/blank'
+else
+  require 'core_ext/object/blank'
+end
 require 'equalizer'
 require 'representable/json'
 require 'oj'


### PR DESCRIPTION
This eliminates a warning when running in Rails.

```bash
/usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/tracker_api-0.2.10/lib/core_ext/object/blank.rb:103:warning: already initialized constant String::BLANK_RE
/usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/object/blank.rb:102:warning: previous definition of BLANK_RE was here
```