### PR TITLE
Retrieve client comments directly - given a specific story

### DIFF
--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -159,6 +159,12 @@ module TrackerApi
       Endpoints::Activity.new(self).get(params)
     end
 
+    # Provides a list of all comments for a specific story
+    #
+    def comments(project_id, story_id)
+      Endpoints::Comments.new(self).get(project_id,story_id)
+    end
+
     private
 
     def parse_query_and_convenience_headers(path, options)


### PR DESCRIPTION
* Add 'comments' method to Client.rb that pulls comments from a
  story, given there is a story_id and project_id provided