### PR TITLE
Remove direct dependency on Oj for use with jruby

### DIFF
--- a/lib/tracker_api.rb
+++ b/lib/tracker_api.rb
@@ -11,14 +11,15 @@ else
 end
 require 'equalizer'
 require 'representable/json'
-require 'oj'
+require 'multi_json'
 
 # stdlib
 require 'addressable/uri'
 require 'forwardable'
 require 'logger'
 
-Oj.default_options = {:mode => :compat }
+MultiJson.load_options = {:mode => :compat}
+MultiJson.dump_options = {:mode => :compat}
 
 module TrackerApi
   autoload :Error, 'tracker_api/error'

--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -190,7 +190,7 @@ module TrackerApi
       headers = options[:headers]
 
       if (method == :post || method == :put) && options[:body].blank?
-        body                    = Oj.dump(params)
+        body                    = MultiJson.dump(params)
         headers['Content-Type'] = 'application/json'
 
         params = {}

--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'multi_json'
 
   spec.add_dependency 'addressable'
   spec.add_dependency 'virtus'
@@ -31,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'excon'
   spec.add_dependency 'equalizer'
-  spec.add_dependency 'oj'
   spec.add_dependency 'representable'
+  spec.add_dependency 'multi_json'
 end


### PR DESCRIPTION
Change to depend on the multi_json gem instead of Oj so that the tracker_api can
be used as part of jruby as well. The multi_json gem will default to using Oj if
it is available anyway.