### PR TITLE
Add completed_at field to epics resource

### DIFF
--- a/lib/tracker_api/resources/epic.rb
+++ b/lib/tracker_api/resources/epic.rb
@@ -17,6 +17,7 @@ module TrackerApi
       attribute :name, String
       attribute :project_id, Integer
       attribute :updated_at, DateTime
+      attribute :completed_at, DateTime
       attribute :url, String
 
       class UpdateRepresenter < Representable::Decorator


### PR DESCRIPTION
For my project I need to know, if epic is closed. 
So I want add "completed_at" field to epic resource.