### PR TITLE
updating readme to remove old version of gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It’s powered by [Faraday](https://github.com/lostisland/faraday) and [Virtus](
 
 Add this line to your application's Gemfile:
 ```ruby
-gem 'tracker_api', '~> 0.2.0'
+gem 'tracker_api'
 ```
 
 And then execute:


### PR DESCRIPTION
I made the mistake of assuming the README was updated and tried working with the really old version of the gem mentioned. I think to be safe, the version should just be removed from the readme, and let the user decide how to setup their gemspec file.