### PR TITLE
add story#add_owner method using owner's API

### DIFF
--- a/lib/tracker_api/endpoints/story_owners.rb
+++ b/lib/tracker_api/endpoints/story_owners.rb
@@ -15,6 +15,11 @@ module TrackerApi
           Resources::Person.new({ story_id: story_id }.merge(owner))
         end
       end
+
+      def create(project_id, story_id, params={})
+        data = client.post("/projects/#{project_id}/stories/#{story_id}/owners", params: params)
+        Resources::Person.new({ client: client }.merge(data))
+      end
     end
   end
 end

--- a/lib/tracker_api/resources/story.rb
+++ b/lib/tracker_api/resources/story.rb
@@ -78,6 +78,18 @@ module TrackerApi
         self.labels = (labels ? labels.dup : []).push(new_label)
       end
 
+      # Assigns owner of story
+      # @param [Person|Integer] owner
+      def add_owner(person)
+        person_id = if person.kind_of?(Person)
+                     person.id
+                   else
+                     person
+                   end
+
+        Endpoints::StoryOwners.new(client).create(project_id, id, id: person_id)
+      end
+
       # Provides a list of all the activity performed on the story.
       #
       # @param [Hash] params


### PR DESCRIPTION

somehow I couldn't add owner using  self.owners= method, so I add add_owner method using owner's API 

+ add attribute person for Comment model, because it's needed to get person object directly from comment

