### PR TITLE
Added story#add_owner

### DIFF
--- a/lib/tracker_api/resources/story.rb
+++ b/lib/tracker_api/resources/story.rb
@@ -75,7 +75,22 @@ module TrackerApi
         end
 
         # Use attribute writer to get coercion and dirty tracking.
-        self.labels = (labels ? labels.dup : []).push(new_label)
+        self.labels = (labels ? labels.dup : []).push(new_label).uniq
+      end
+
+      # Adds a new owner to the story.
+      #
+      # @param [Person|Fixnum] owner
+      def add_owner(owner)
+        owner_id = if owner.kind_of?(Fixnum)
+          owner_id = owner
+        else
+          raise ArgumentError, 'Valid Person expected.' unless owner.instance_of?(Resources::Person)
+          owner_id = owner.id
+        end
+
+        # Use attribute writer to get coercion and dirty tracking.
+        self.owner_ids = (owner_ids ? owner_ids.dup : []).push(owner_id).uniq
       end
 
       # Provides a list of all the activity performed on the story.

--- a/test/story_test.rb
+++ b/test/story_test.rb
@@ -153,6 +153,39 @@ describe TrackerApi::Resources::Story do
     end
   end
 
+  describe '.add_owner' do
+    it 'add owner to a story' do
+      VCR.use_cassette('get story', record: :new_episodes) do
+        story = project.story(story_id)
+
+        # clear current owners
+        story.owner_ids = []
+
+        story.add_owner(TrackerApi::Resources::Person.new(id: 123))
+
+        story.owner_ids.wont_be_empty
+        story.owner_ids.must_equal [123]
+      end
+    end
+
+    it 'add owners by id to a story' do
+      VCR.use_cassette('get story', record: :new_episodes) do
+        story = project.story(story_id)
+
+        # clear current owners
+        story.owner_ids = []
+
+        story.add_owner(123)
+        story.add_owner(456)
+        # test dups are not added
+        story.add_owner(123)
+
+        story.owner_ids.wont_be_empty
+        story.owner_ids.must_equal [123, 456]
+      end
+    end
+  end
+
   describe '.tasks' do
     it 'gets all tasks for this story with eager loading' do
       VCR.use_cassette('get story with tasks', record: :new_episodes) do


### PR DESCRIPTION
This might be an acceptable compromise to not supporting `<<` for `owner_ids`. Also consistent with the `add_label` interface which exists for the same reasons.