### PR TITLE
relax dependency of faraday.

### DIFF
--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable'
   spec.add_dependency 'virtus'
-  spec.add_dependency 'faraday', '~> 0.9.0'
+  spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'excon'
   spec.add_dependency 'equalizer'


### PR DESCRIPTION
'faraday_middleware' has already set a dependency of faraday.
So, I think able to delete faraday's dependency.