### PR TITLE
Use net_http as default HTTP adapter for Jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  # - "jruby"
+  - "jruby"
   #  - rbx
   #  - "1.8.7"
 # uncomment this line if your project needs to run something other than `rake`:

--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -25,7 +25,7 @@ module TrackerApi
       @url               = Addressable::URI.parse(url).to_s
       @api_version       = options.fetch(:api_version, '/services/v5')
       @logger            = options.fetch(:logger, ::Logger.new(nil))
-      adapter            = options.fetch(:adapter, :excon)
+      adapter            = options.fetch(:adapter) { defined?(JRUBY_VERSION) ? :net_http : :excon }
       connection_options = options.fetch(:connection_options, { ssl: { verify: true } })
       @auto_paginate     = options.fetch(:auto_paginate, true)
       @token             = options[:token]

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -20,7 +20,7 @@ VCR.configure do |c|
   c.ignore_localhost         = true
   c.cassette_library_dir     = File.expand_path('../vcr/cassettes', __FILE__).to_s
   c.default_cassette_options = { serialize_with: :json }
-  c.hook_into :excon
+  c.hook_into :faraday
   c.allow_http_connections_when_no_cassette = false
 end
 


### PR DESCRIPTION
Fixes #123 

Currently `excon` does not work out of the box with Jruby due to a more restrictive cipher set.  In order to prevent usability issues this sets the default adapter to `net_http` for Jruby