### PR TITLE
Update Faraday error handling

### DIFF
--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -223,7 +223,7 @@ module TrackerApi
         req.body = body
       end
       response
-    rescue Faraday::Error::ClientError => e
+    rescue Faraday::ClientError => e
       status_code = e.response[:status]
       case status_code
       when 400..499 then raise TrackerApi::Errors::ClientError.new(e)

--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -223,7 +223,7 @@ module TrackerApi
         req.body = body
       end
       response
-    rescue Faraday::ClientError => e
+    rescue Faraday::ClientError, Faraday::ServerError => e
       status_code = e.response[:status]
       case status_code
       when 400..499 then raise TrackerApi::Errors::ClientError.new(e)

--- a/lib/tracker_api/error.rb
+++ b/lib/tracker_api/error.rb
@@ -7,7 +7,7 @@ module TrackerApi
       @response          = wrapped_exception.response
       message            = if wrapped_exception.is_a?(Faraday::ParsingError)
                              wrapped_exception.message
-                           elsif wrapped_exception.is_a?(Faraday::ClientError)
+                           elsif [Faraday::ClientError, Faraday::ServerError].any? { |err| wrapped_exception.is_a?(err) }
                              wrapped_exception.response.inspect
                            else
                              wrapped_exception.instance_variable_get(:@wrapped_exception).inspect

--- a/lib/tracker_api/error.rb
+++ b/lib/tracker_api/error.rb
@@ -5,9 +5,9 @@ module TrackerApi
     def initialize(wrapped_exception)
       @wrapped_exception = wrapped_exception
       @response          = wrapped_exception.response
-      message            = if wrapped_exception.is_a?(Faraday::Error::ParsingError)
+      message            = if wrapped_exception.is_a?(Faraday::ParsingError)
                              wrapped_exception.message
-                           elsif wrapped_exception.is_a?(Faraday::Error::ClientError)
+                           elsif wrapped_exception.is_a?(Faraday::ClientError)
                              wrapped_exception.response.inspect
                            else
                              wrapped_exception.instance_variable_get(:@wrapped_exception).inspect

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -35,7 +35,13 @@ describe TrackerApi::Error do
   # Simulate the error Faraday will raise with a specific HTTP status code so
   # we can test our rescuing of those errors
   def mock_faraday_error(status_code)
+    mocked_error_class = if (500..599).include?(status_code)
+      Faraday::ServerError
+    else
+      Faraday::ClientError
+    end
+
     ::Faraday::Connection.any_instance.stubs(:get).
-      raises(::Faraday::ClientError.new(nil, { status: status_code}))
+      raises(mocked_error_class.new(nil, { status: status_code}))
   end
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -22,7 +22,7 @@ describe TrackerApi::Error do
       end
     end
   end
-  
+
   it 'raises RuntimeError for HTTP status codes < 400 and > 500' do
     [399, 600].each do |status_code|
       mock_faraday_error(status_code)

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -36,6 +36,6 @@ describe TrackerApi::Error do
   # we can test our rescuing of those errors
   def mock_faraday_error(status_code)
     ::Faraday::Connection.any_instance.stubs(:get).
-      raises(::Faraday::Error::ClientError.new(nil, { status: status_code}))
+      raises(::Faraday::ClientError.new(nil, { status: status_code}))
   end
 end


### PR DESCRIPTION
A [recent Faraday update](https://github.com/lostisland/faraday/tree/v0.16.1) re-organized their error classes and added a new one. This PR updates references to deprecated classes and includes the new one.